### PR TITLE
Version 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.17.0..dev)
+## [Unreleased](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.18.0..dev)
+
+## [2.18.0](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.18.0..2.17.0) - 2024-03-25
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.17.0..dev)
 
+### Changed
+
+- [Utils] Add RSALv2 license in third-party generator scripts ([#139](https://github.com/Orange-OpenSource/floss-toolbox/issues/139))
+
 ## [2.17.0](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.17.0..2.16.0) - 2024-03-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Utils] Add licenses names for third-party generator and prompt scripts and new licenses ([#141](https://github.com/Orange-OpenSource/floss-toolbox/issues/141))
 - [Utils] Add RSALv2 license in third-party generator scripts ([#139](https://github.com/Orange-OpenSource/floss-toolbox/issues/139))
 
 ## [2.17.0](https://github.com/Orange-OpenSource/floss-toolbox/compare/2.17.0..2.16.0) - 2024-03-22

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,5 +39,5 @@ keywords:
   - audits
   - history
 license: Apache-2.0
-version: v2.17.0
-date-released: '2024-03-22'
+version: v2.18.0
+date-released: '2024-03-25'

--- a/toolbox/utils/third-party-generator/configuration.py
+++ b/toolbox/utils/third-party-generator/configuration.py
@@ -10,7 +10,7 @@
 # Authors: See CONTRIBUTORS.txt
 # Software description: A toolbox of scripts to help work of forges admins and open source referents
 
-# Version.............: 1.1.0
+# Version.............: 1.2.0
 # Since...............: 12/03/2024
 # Description.........: Just to list managed licenses and share values between scripts
 
@@ -45,6 +45,7 @@ LICENSES = {
     "SSPL-1.0": "https://spdx.org/licenses/SSPL-1.0.html",          # Service Side Public License v1
     "BUSL-1.1": "https://spdx.org/licenses/BUSL-1.1.html",          # Business Source License 1.1
     "FSL-1.1-Apache-2.0": "https://fsl.software/",                  # Functional Source License, Version 1.1, Apache 2.0 Future License
-    "FSL-1.1-MIT": "https://fsl.software/"                          # Functional Source License, Version 1.1, MIT Future License
+    "FSL-1.1-MIT": "https://fsl.software/",                         # Functional Source License, Version 1.1, MIT Future License
+    "RSALv2": "https://redis.com/legal/rsalv2-agreement/"           # Redis Source Available License 2.0
 }
 LICENSES_NAMES = list(LICENSES)

--- a/toolbox/utils/third-party-generator/configuration.py
+++ b/toolbox/utils/third-party-generator/configuration.py
@@ -27,7 +27,7 @@ DEFAULT_AVOID_FIELD_SYMBOL = "?"
 # Please refer to https://opensource.org/licenses or https://spdx.org/licenses/
 # Use SPDX short identifier as key, full name and URL of license text as values
 LICENSES = {
-    "Other": ["Other", "<to be completed>"], # If not listed bellow in this exact SPDX short identifier
+    "Other": ["Other", "<to be completed>"], # If not listed bellow in a known exact SPDX short identifier
 
     "Apache-2.0": ["Apache 2.0 License", "https://opensource.org/license/apache-2-0"],
     "MIT": ["MIT License", "https://opensource.org/license/mit"],

--- a/toolbox/utils/third-party-generator/configuration.py
+++ b/toolbox/utils/third-party-generator/configuration.py
@@ -10,7 +10,7 @@
 # Authors: See CONTRIBUTORS.txt
 # Software description: A toolbox of scripts to help work of forges admins and open source referents
 
-# Version.............: 1.2.0
+# Version.............: 2.0.0
 # Since...............: 12/03/2024
 # Description.........: Just to list managed licenses and share values between scripts
 
@@ -25,27 +25,39 @@ DEFAULT_AVOID_FIELD_SYMBOL = "?"
 # ------------------
 
 # Please refer to https://opensource.org/licenses or https://spdx.org/licenses/
-# Use SPDX short identifier as key, URL of license text as value
+# Use SPDX short identifier as key, full name and URL of license text as values
 LICENSES = {
-    "Other": "<to be completed>",                                   # If not listed bellow in this exact SPDX short identifier
-    "MIT": "https://opensource.org/license/mit",                    # MIT
-    "0BSD": "https://opensource.org/license/0bsd",                  # Zero-Clause BSD
-    "BSD-2-Clause": "https://opensource.org/license/bsd-2-clause",  # FreeBSD / BSD 2-Clause
-    "BSD-3-Clause": "https://opensource.org/license/bsd-3-clause",  # New BSD / BSD 3-Claise
-    "BSD-4-Clause": "https://spdx.org/licenses/BSD-4-Clause.html",  # Original BSD / Old BSD / BSD 4-Clause
-    "Apache-2.0": "https://opensource.org/license/apache-2-0",      # Apache 2.0
-    "MPL-2.0": "https://opensource.org/license/mpl-2-0",            # Mozilla Public License 2.0
-    "EPL-2.0": "https://opensource.org/license/epl-2.0",            # Eclipse Public License 2.0
-    "LGPL-2.0-only": "https://opensource.org/license/lgpl-2-0",     # GNU Library General Public License 2.0
-    "LGPL-2.1": "https://opensource.org/license/lgpl-2-1",          # GNU Library General Public License 2.1
-    "LGPL-3.0-only": "https://opensource.org/license/lgpl-3-0",     # GNU Library General Public License 3.0
-    "GPL-2.0": "https://opensource.org/license/gpl-2-0",            # GNU General Public License version 2
-    "GPL-3.0-only": "https://opensource.org/license/gpl-3-0",       # GNU General Public License version 3
-    "AGPL-3.0-only": "https://opensource.org/license/agpl-v3",      # GNU Affero General Public License version 3
-    "SSPL-1.0": "https://spdx.org/licenses/SSPL-1.0.html",          # Service Side Public License v1
-    "BUSL-1.1": "https://spdx.org/licenses/BUSL-1.1.html",          # Business Source License 1.1
-    "FSL-1.1-Apache-2.0": "https://fsl.software/",                  # Functional Source License, Version 1.1, Apache 2.0 Future License
-    "FSL-1.1-MIT": "https://fsl.software/",                         # Functional Source License, Version 1.1, MIT Future License
-    "RSALv2": "https://redis.com/legal/rsalv2-agreement/"           # Redis Source Available License 2.0
+    "Other": ["Other", "<to be completed>"], # If not listed bellow in this exact SPDX short identifier
+
+    "Apache-2.0": ["Apache 2.0 License", "https://opensource.org/license/apache-2-0"],
+    "MIT": ["MIT License", "https://opensource.org/license/mit"],
+
+    "0BSD": ["BSD Zero-Clause License", "https://opensource.org/license/0bsd"],
+    "BSD-2-Clause": ["Free BSD License", "https://opensource.org/license/bsd-2-clause"],
+    "BSD-3-Clause": ["BSD New License", "https://opensource.org/license/bsd-3-clause"],
+    "BSD-3-Clause-No-Military-License": ["BSD 3-Clause No Military License", "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html"],
+    "BSD-3-Clause-No-Nuclear-License": ["BSD 3-Clause No Nuclear License", "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html"],
+    "BSD-4-Clause": ["BSD Original License", "https://spdx.org/licenses/BSD-4-Clause.html"], # Or also "BSD Old"
+    
+    "EPL-2.0": ["Eclipse Public License 2.0", "https://opensource.org/license/epl-2.0"],
+    "MPL-2.0": ["Mozilla Public License 2.0", "https://opensource.org/license/mpl-2-0"],
+    "LGPL-2.0-only": ["GNU Library General Public License 2.0", "https://opensource.org/license/lgpl-2-0"],
+    "LGPL-2.1": ["GNU Library General Public License 2.1", "https://opensource.org/license/lgpl-2-1"],
+    "LGPL-3.0-only": ["GNU Library General Public License 3.0", "https://opensource.org/license/lgpl-3-0"],
+
+    "GPL-2.0": ["GNU General Public License version 2", "https://opensource.org/license/gpl-2-0"],
+    "GPL-3.0-only": ["GNU General Public License version 3", "https://opensource.org/license/gpl-3-0"],
+    "AGPL-3.0-only": ["GNU Affero General Public License version 3", "https://opensource.org/license/agpl-v3"],
+    
+    "SSPL-1.0": ["Server Side Public License v1", "https://spdx.org/licenses/SSPL-1.0.html"],
+    "BUSL-1.1": ["Business Source License 1.1", "https://spdx.org/licenses/BUSL-1.1.html"],
+    "FSL-1.1-Apache-2.0": ["Functional Source License, Version 1.1, Apache 2.0 Future License", "https://fsl.software/"],
+    "FSL-1.1-MIT": ["Functional Source License, Version 1.1, MIT Future License", "https://fsl.software/"],
+    "RSALv2": ["Redis Source Available License 2.0", "https://redis.com/legal/rsalv2-agreement/"],
+
+    "prosperity-2.0 ": ["Prosperity Public License 2.0", "https://github.com/licensezero/prosperity-public-license/blob/v2.0.0/LICENSE.mustache"],
+    "Unlicense": ["The Unlicense License", "https://unlicense.org/"],
+    "Hippocratic-2.1": ["Hippocratic License 2.1", "https://spdx.org/licenses/Hippocratic-2.1.html"]
 }
+
 LICENSES_NAMES = list(LICENSES)

--- a/toolbox/utils/third-party-generator/third-party-generator.py
+++ b/toolbox/utils/third-party-generator/third-party-generator.py
@@ -10,7 +10,7 @@
 # Authors: See CONTRIBUTORS.txt
 # Software description: A toolbox of scripts to help work of forges admins and open source referents
 
-# Version.............: 3.0.0
+# Version.............: 3.1.0
 # Since...............: 12/03/2024
 # Description.........: Builds a third-party Markdown file based on a CSV file and a delimiter
 
@@ -83,10 +83,11 @@ requirements of the relevant license of the Third Party Software they are using.
             
             unique_computed_components.add(name) 
             repository = component_fields[1]
-            license_name = component_fields[2]
+            license_identifier = component_fields[2]
             copyright = component_fields[3]
             version = component_fields[4]
-            license_url = LICENSES[license_name]
+            license_name = LICENSES[license_identifier][0]
+            license_url = LICENSES[license_identifier][1]
             component_entry = """## {name}
 """.format(name=name)
             
@@ -107,7 +108,7 @@ Copyright {copyright}
                 print(f"- No copyright defined for component '{name}'")
 
             component_entry += """
-**{name}** is distributed under the terms and conditions of the [{license} License]({url}).
+**{name}** is distributed under the terms and conditions of the [{license}]({url}).
 You may download the source code on the [following website]({repository}).""".format(name=name, license=license_name, url=license_url, repository=repository)
             result_file.write(component_entry)
             result_file.write("\n\n")


### PR DESCRIPTION
- [Utils] Add licenses names for third-party generator and prompt scripts and new licenses ([#141](https://github.com/Orange-OpenSource/floss-toolbox/issues/141))
- [Utils] Add RSALv2 license in third-party generator scripts ([#139](https://github.com/Orange-OpenSource/floss-toolbox/issues/139))
